### PR TITLE
Force load package with sockets and fix references to images

### DIFF
--- a/WOTC_LW2SecondaryWeapons/Config/XComContent.ini
+++ b/WOTC_LW2SecondaryWeapons/Config/XComContent.ini
@@ -1,3 +1,4 @@
 [Content.MapContent]
 .Map=$ALL
 .Package=UILibrary_LWSecondariesWOTC
+.Package=LWSoldierSockets

--- a/WOTC_LW2SecondaryWeapons/Config/XComGameData_WeaponData.ini
+++ b/WOTC_LW2SecondaryWeapons/Config/XComGameData_WeaponData.ini
@@ -6,9 +6,9 @@
 ;  ??????????????????????????
 [WOTC_LW2SecondaryWeapons.X2Item_ArcthrowerWeapon]
 
-Arcthrower_CV_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Conv_Arcthrower"
-Arcthrower_MG_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Mag_Arcthrower"
-Arcthrower_BM_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Beam_Arcthrower"
+Arcthrower_CV_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Conv_Arcthrower"
+Arcthrower_MG_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Mag_Arcthrower"
+Arcthrower_BM_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Beam_Arcthrower"
 
 Arcthrower_CV_GameArchetype="LWArcthrowerWOTC.Archetypes.WP_Arcthrower_CV"
 Arcthrower_MG_GameArchetype="LWArcthrowerWOTC.Archetypes.WP_Arcthrower_MG"
@@ -141,9 +141,9 @@ Arcthrower_BEAM_INDIVIDUAL_LEGEND_TRADINGPOSTVALUE = 10
 ;  ??????????????????????????
 [WOTC_LW2SecondaryWeapons.X2Item_LWCombatKnife]
 
-CombatKnife_CV_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Conv_CombatKnife"
-CombatKnife_MG_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Mag_CombatKnife"
-CombatKnife_BM_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Beam_CombatKnife"
+CombatKnife_CV_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Conv_CombatKnife"
+CombatKnife_MG_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Mag_CombatKnife"
+CombatKnife_BM_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Beam_CombatKnife"
 
 CombatKnife_CV_GameArchetype="LWCombatKnifeWOTC.Archetypes.WP_CombatKnife_CV"
 CombatKnife_MG_GameArchetype="LWCombatKnifeWOTC.Archetypes.WP_CombatKnife_MG"
@@ -248,9 +248,9 @@ CombatKnife_BEAM_INDIVIDUAL_LEGEND_TRADINGPOSTVALUE = 7
 ;  ??????????????????????????
 [WOTC_LW2SecondaryWeapons.X2Item_LWGauntlet]
 
-Gauntlet_CV_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Conv_LWGauntlet"
-Gauntlet_MG_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Mag_PlatedGauntlet"
-Gauntlet_BM_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Beam_PowerGauntlet"
+Gauntlet_CV_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Conv_LWGauntlet"
+Gauntlet_MG_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Mag_PlatedGauntlet"
+Gauntlet_BM_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Beam_PowerGauntlet"
 
 Gauntlet_CV_GameArchetype="LWGauntletWOTC.Archetypes.WP_Gauntlet_RocketLauncher_CV"
 Gauntlet_MG_GameArchetype="LWGauntletWOTC.Archetypes.WP_Gauntlet_RocketLauncher_MG"
@@ -397,9 +397,9 @@ Gauntlet_BEAM_INDIVIDUAL_LEGEND_TRADINGPOSTVALUE = 22
 ;  ??????????????????????????
 [WOTC_LW2SecondaryWeapons.X2Item_LWHolotargeter]
 
-Holotargeter_CV_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Conv_LWHolotargeter"
-Holotargeter_MG_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Mag_LWHolotargeter"
-Holotargeter_BM_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Beam_LWHolotargeter"
+Holotargeter_CV_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Conv_LWHolotargeter"
+Holotargeter_MG_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Mag_LWHolotargeter"
+Holotargeter_BM_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Beam_LWHolotargeter"
 
 Holotargeter_CV_GameArchetype="LWHolotargeterWOTC.Archetypes.WP_Holotargeter_CV"
 Holotargeter_MG_GameArchetype="LWHolotargeterWOTC.Archetypes.WP_Holotargeter_MG"
@@ -505,9 +505,9 @@ Holotargeter_BEAM_INDIVIDUAL_LEGEND_TRADINGPOSTVALUE = 8
 ;  ??????????????????????????
 [WOTC_LW2SecondaryWeapons.X2Item_LWSawedOffShotgun]
 
-SawedOffShotgun_CV_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Conv_SawedOffShotgun"
-SawedOffShotgun_MG_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Mag_SawedOffShotgun"
-SawedOffShotgun_BM_UIImage="img:///UILibrary_LWSecondariesWOTC..Inv_Beam_SawedOffShotgun"
+SawedOffShotgun_CV_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Conv_SawedOffShotgun"
+SawedOffShotgun_MG_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Mag_SawedOffShotgun"
+SawedOffShotgun_BM_UIImage="img:///UILibrary_LWSecondariesWOTC.Inv_Beam_SawedOffShotgun"
 
 SawedOffShotgun_CV_GameArchetype="LWSawedOffShotgunWOTC.Archetypes.WP_SawedOffShotgun_CV"
 SawedOffShotgun_MG_GameArchetype="LWSawedOffShotgunWOTC.Archetypes.WP_SawedOffShotgun_MG"


### PR DESCRIPTION
Force loading package with sockets removes the redscreens associated with loading sockets.
References to images got broken when I did find & replace previously. (they still worked, but less reliably) This PR fixes them.